### PR TITLE
Add MemberCore deployment script

### DIFF
--- a/mcdeployall
+++ b/mcdeployall
@@ -1,0 +1,101 @@
+#!/usr/bin/env php
+<?php
+
+if (!defined('STDIN')) {
+    echo "You're unauthorized to view this page.\n";
+    exit(1);
+}
+
+if (!isset($argv[1])) {
+    echo "Usage: ./script/mcdeployall [version-number]\n";
+    exit(1);
+}
+
+$version = $argv[1];
+
+if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $version)) {
+    echo "Improper version format.\n";
+    exit(1);
+}
+
+$membercore_plugin_dir  = dirname(__DIR__);
+$membercore_plugin_slug = basename($membercore_plugin_dir);
+$plugins_dir            = dirname($membercore_plugin_dir);
+
+if (getcwd() !== $membercore_plugin_dir) {
+    echo "This script must be run from within the plugin root directory.\n";
+    exit(1);
+}
+
+if (strpos($membercore_plugin_slug, 'membercore') !== 0) {
+    echo "This script must be run from within a MemberCore plugin directory.\n";
+    exit(1);
+}
+
+$plugins = [
+    $membercore_plugin_slug,
+    str_replace('membercore', 'memberpress', $membercore_plugin_slug),
+    str_replace('membercore', 'wishlistmember', $membercore_plugin_slug),
+];
+
+$project_ids = [];
+
+foreach($plugins as $plugin) {
+    $plugin_path = $plugins_dir . '/' . $plugin;
+
+    if (!file_exists($plugin_path)) {
+        echo "The $plugin plugin was not found.\n";
+        exit(1);
+    }
+
+    if (!is_dir($plugin_path . '/script')) {
+        echo "The $plugin plugin does not have a script directory.\n";
+        exit(1);
+    }
+
+    if (!file_exists($plugin_path . '/script/wp-script-config.php')) {
+        echo "The $plugin plugin does not have a script/wp-script-config.php file.\n";
+        exit(1);
+    }
+
+    $config = file_get_contents($plugin_path . '/script/wp-script-config.php');
+
+    if (!preg_match('/define\(\'WP_SCRIPT_TEXTDOMAIN\',\s*\'([^\']+)\'\)/', $config, $matches)) {
+        echo "The $plugin plugin does not have a WP_SCRIPT_TEXTDOMAIN defined.\n";
+        exit(1);
+    }
+
+    if (!preg_match('/define\(\'MOTHERSHIP_URL\',\s*\'([^\']+)\'\)/', $config, $matches)) {
+        echo "The $plugin plugin does not have a MOTHERSHIP_URL defined.\n";
+        exit(1);
+    }
+
+    if (!preg_match('/define\(\'MOTHERSHIP_API_KEY\',\s*\'([^\']+)\'\)/', $config, $matches)) {
+        echo "The $plugin plugin does not have a MOTHERSHIP_API_KEY defined.\n";
+        exit(1);
+    }
+
+    if (!preg_match('/define\(\'MOTHERSHIP_PROJECT_ID\',\s*\'([^\']+)\'\)/', $config, $matches)) {
+        echo "The $plugin plugin does not have a MOTHERSHIP_PROJECT_ID defined.\n";
+        exit(1);
+    } elseif (empty($matches[1]) || !is_numeric($matches[1])) {
+        echo "The $plugin plugin does not have a valid MOTHERSHIP_PROJECT_ID defined.\n";
+        exit(1);
+    }
+
+    if (in_array($matches[1], $project_ids, true)) {
+        echo "The $plugin plugin has a duplicate MOTHERSHIP_PROJECT_ID defined.\n";
+        exit(1);
+    }
+
+    $project_ids[] = $matches[1];
+}
+
+foreach ($plugins as $plugin) {
+    chdir($plugins_dir . '/' . $plugin);
+    $command = "./script/mcdevdeploy $version";
+    echo "\n$command\n";
+    system($command);
+}
+
+exit(0);

--- a/mcdevdeploy
+++ b/mcdevdeploy
@@ -1,0 +1,75 @@
+#!/usr/bin/env php
+<?php
+
+if (!defined('STDIN')) {
+    echo "You're unauthorized to view this page.\n";
+    exit(1);
+}
+
+if (!isset($argv[1])) {
+    echo "Usage: ./script/mcdevdeploy [version-number]\n";
+    exit(1);
+}
+
+$version = $argv[1];
+
+if (!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $version)) {
+    echo "Improper version format.\n";
+    exit(1);
+}
+
+if (getcwd() !== dirname(__DIR__)) {
+    echo "This script must be run from within the plugin root directory.\n";
+    exit(1);
+}
+
+if (!file_exists(__DIR__ . '/wp-script-config.php')) {
+    echo "The script/wp-script-config.php file wasn't found.\n";
+    exit(1);
+}
+
+require __DIR__ . '/wp-script-config.php';
+
+if (empty(MOTHERSHIP_URL) || empty(MOTHERSHIP_API_KEY) || empty(MOTHERSHIP_PROJECT_ID)) {
+    echo "The MOTHERSHIP_URL, MOTHERSHIP_API_KEY, and MOTHERSHIP_PROJECT_ID constants must be defined in script/wp-script-config.php\n";
+    exit(1);
+}
+
+echo "!! Deploying version \"{$version}\"\n";
+
+if (!defined('MY_PLUGIN_MAIN_FILE')) {
+    define('MY_PLUGIN_MAIN_FILE', WP_SCRIPT_TEXTDOMAIN . '.php');
+}
+
+echo "!! Merging develop into master and issuing release\n";
+
+$commands   = array();
+$commands[] = "/usr/bin/git checkout develop";
+$commands[] = "/usr/bin/git pull origin develop";
+$commands[] = "/usr/bin/git checkout master";
+$commands[] = "/usr/bin/git pull origin master";
+$commands[] = "/usr/bin/git merge develop";
+$commands[] = "/usr/bin/git push origin master";
+$commands[] = "/usr/bin/perl -p -i -e 's/^Version: (.*)$/Version: {$version}/' ./" . MY_PLUGIN_MAIN_FILE;
+$commands[] = './script/mki18n';
+$commands[] = './script/rmlb';
+$commands[] = './script/cleartrailingwhitespace';
+$commands[] = './script/rmtabs';
+$commands[] = "/usr/bin/git commit -am 'Bump master to version {$version} [ci skip]'";
+$commands[] = "/usr/bin/git push origin master";
+$commands[] = "/usr/bin/git tag {$version}";
+$commands[] = "/usr/bin/git push origin {$version}";
+$commands[] = '/usr/bin/curl -d "apikey=' . MOTHERSHIP_API_KEY . '" ' . MOTHERSHIP_URL . '/versions/deploy/' . MOTHERSHIP_PROJECT_ID . '/' . $version;
+$commands[] = "/usr/bin/git checkout develop";
+$commands[] = "/usr/bin/git merge master";
+$commands[] = "/usr/bin/git push origin develop";
+
+foreach ($commands as $command) {
+    echo "\n$command\n";
+    system($command);
+    sleep(1);
+}
+
+echo "!! Merged master back into develop and pushed to \"origin develop\"\n";
+
+exit(0);


### PR DESCRIPTION
Adds two new scripts:

`./mcdevdeploy` - deploys a single MemberCore plugin. This is similar to the existing `devdeploy` script, but with additional error checking, and it avoids the GitHub actions by adding `[ci skip]` to the commit message. It also pulls into develop and master at the start. This isn't intended to be used directly, but it could be if a single plugin needs to be deployed (if there was an error deploying one of them for example).

`./mcdeployall` - deploys all 3 MemberCore plugins sequentially. Must be run from within a MemberCore plugin directory.

## Setup

`git clone` and set up Mothership deployments on all 3 versions of the plugin, using the drip-tags repo as an example, we'd want these three directories being a git clone of the plugin, with the `script/` directory in place and `wp-script-config.php` configured for each plugin:

- membercore-drip-tags
- memberpress-drip-tags
- wishlistmember-drip-tags

Then run the deployment with the commands below (must be started from within the MemberCore version of the plugin):

```
cd membercore-drip-tags
./script/mcdeployall 1.2.3
```

Closes #1.