### PR TITLE
Add optional secondary textdomain support to mki18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,20 @@ same repo, define the optional `_2` constants in `wp-script-config.php`:
 ```
 define('WP_SCRIPT_TEXTDOMAIN', 'my-plugin');
 define('WP_SCRIPT_LANGUAGES_DIR', 'languages');
-define('WP_SCRIPT_EXCLUDE', 'pro,vendor,vendor-prefixed,node_modules,assets,tests,docs,bin');
+define('WP_SCRIPT_EXCLUDE', 'pro,vendor,node_modules,assets/js/build,tests,docs,bin');
 
 define('WP_SCRIPT_TEXTDOMAIN_2', 'my-plugin-pro');
 define('WP_SCRIPT_LANGUAGES_DIR_2', 'pro/languages');
 define('WP_SCRIPT_INCLUDE_2', 'pro');
-define('WP_SCRIPT_EXCLUDE_2', 'pro/vendor,pro/vendor-prefixed,pro/node_modules,pro/assets');
+define('WP_SCRIPT_EXCLUDE_2', 'pro/vendor,pro/node_modules,pro/assets/js/build');
 ```
+
+> **Don't exclude `vendor-prefixed`.** Plugins that use Strauss to bundle
+> in-house libraries (`ground-level-*`, etc.) ship real user-facing strings in
+> that tree, tagged with the plugin's own textdomain — excluding it silently
+> drops them from the `.pot`. For the same reason, exclude built JS output
+> (`assets/js/build`) rather than the whole `assets/` directory, since
+> `wp i18n make-pot` also extracts translatable strings from JS.
 
 `mki18n` will then run two passes — `./languages/my-plugin.pot` and
 `./pro/languages/my-plugin-pro.pot` — each scoped to its own subtree and

--- a/README.md
+++ b/README.md
@@ -62,8 +62,37 @@ And
 ./script/mki18n
 find . -regex "^\.\/[^/]*\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i 'memberpress' {} \;
 find . -regex "^\.\/app.*\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i 'memberpress' {} \;
-/usr/bin/env php ./script/i18n/makepot.php wp-plugin . ./i18n/memberpress.pot
+/usr/bin/env wp i18n make-pot . ./i18n/memberpress.pot --slug=memberpress --domain=memberpress
 ```
+
+`wp i18n make-pot` extracts strings from PHP **and** JS/JSX/TSX in one pass,
+so JavaScript `__('text', 'my-domain')` calls are picked up automatically.
+
+### Multiple textdomains in one project
+
+For projects that bundle a Pro add-on (or any second textdomain) inside the
+same repo, define the optional `_2` constants in `wp-script-config.php`:
+
+```
+define('WP_SCRIPT_TEXTDOMAIN', 'my-plugin');
+define('WP_SCRIPT_LANGUAGES_DIR', 'languages');
+define('WP_SCRIPT_EXCLUDE', 'pro,vendor,vendor-prefixed,node_modules,assets,tests,docs,bin');
+
+define('WP_SCRIPT_TEXTDOMAIN_2', 'my-plugin-pro');
+define('WP_SCRIPT_LANGUAGES_DIR_2', 'pro/languages');
+define('WP_SCRIPT_INCLUDE_2', 'pro');
+define('WP_SCRIPT_EXCLUDE_2', 'pro/vendor,pro/vendor-prefixed,pro/node_modules,pro/assets');
+```
+
+`mki18n` will then run two passes — `./languages/my-plugin.pot` and
+`./pro/languages/my-plugin-pro.pot` — each scoped to its own subtree and
+filtered to its own textdomain. Single-domain projects that don't define
+`WP_SCRIPT_TEXTDOMAIN_2` get the original behavior unchanged.
+
+The auto-tag step (`add-textdomain.php`) is skipped when a secondary domain
+is configured, since an untagged call can't be unambiguously assigned to
+either domain. Two-domain projects must tag every gettext call explicitly.
+
 And (if you have a mothership project associated with this git repo)
 
 ```

--- a/mki18n
+++ b/mki18n
@@ -1,19 +1,81 @@
 #!/usr/bin/env php
 <?php
-$my_dir = (isset($argv[1]) && !empty($argv[1])) ? $argv[1] : 'i18n';
-
 if(!defined('STDIN')) { die("You're unauthorized to view this page."); }
 
 if(!file_exists('./script/wp-script-config.php')) { die("Your script/wp-script-config.php file wasn't found."); }
 
 include_once('./script/wp-script-config.php');
 
-$commands = array();
-$commands[] = 'find . -regex "^\.\/[^/]*\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i \'' . WP_SCRIPT_TEXTDOMAIN . '\' {} \;';
-$commands[] = 'find . -regex "^\.\/app.*\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i \'' . WP_SCRIPT_TEXTDOMAIN . '\' {} \;';
-$commands[] = '/usr/bin/env wp i18n make-pot . ./' . $my_dir  . '/' . WP_SCRIPT_TEXTDOMAIN . '.pot';
+/**
+ * Run a single make-pot pass for a given textdomain.
+ *
+ * @param string $domain      Textdomain to filter by.
+ * @param string $pot_dir     Directory the .pot is written to (relative to plugin root).
+ * @param string $exclude     Comma-separated --exclude value (empty to skip flag).
+ * @param string $include     Comma-separated --include value (empty to skip flag).
+ * @param bool   $auto_tag    Whether to run add-textdomain.php first. Skipped automatically
+ *                            when a secondary domain is configured (ambiguous attribution).
+ */
+function wp_script_run_make_pot($domain, $pot_dir, $exclude, $include, $auto_tag) {
+	if (empty($domain)) {
+		echo "\n[skip] empty textdomain — pass not run\n";
+		return;
+	}
+	if ($auto_tag) {
+		$cmds = array(
+			'find . -regex "^\\./[^/]*\\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i \'' . $domain . '\' {} \\;',
+			'find . -regex "^\\./app.*\\.php" -exec /usr/bin/env php ./script/i18n/add-textdomain.php -i \'' . $domain . '\' {} \\;',
+		);
+		foreach ($cmds as $c) { echo "\n\n$c\n"; system($c); sleep(1); }
+	}
 
-foreach($commands as $command) { echo "\n\n$command\n"; system($command); sleep(1); }
+	$pot_path = './' . trim($pot_dir, '/') . '/' . $domain . '.pot';
+
+	$flags = ' --slug=' . escapeshellarg($domain) . ' --domain=' . escapeshellarg($domain);
+	if (!empty($exclude)) { $flags .= ' --exclude=' . escapeshellarg($exclude); }
+	if (!empty($include)) { $flags .= ' --include=' . escapeshellarg($include); }
+
+	$cmd = '/usr/bin/env wp i18n make-pot . ' . escapeshellarg($pot_path) . $flags;
+	echo "\n\n$cmd\n";
+	system($cmd);
+}
+
+// CLI override for the primary languages dir keeps the old `./mki18n my-dir` behavior.
+$cli_dir = (isset($argv[1]) && !empty($argv[1])) ? $argv[1] : null;
+
+$primary_dir = $cli_dir
+	? $cli_dir
+	: (defined('WP_SCRIPT_LANGUAGES_DIR') && WP_SCRIPT_LANGUAGES_DIR ? WP_SCRIPT_LANGUAGES_DIR : 'i18n');
+
+$primary_exclude = defined('WP_SCRIPT_EXCLUDE') ? WP_SCRIPT_EXCLUDE : '';
+$primary_include = defined('WP_SCRIPT_INCLUDE') ? WP_SCRIPT_INCLUDE : '';
+
+$has_secondary = defined('WP_SCRIPT_TEXTDOMAIN_2') && !empty(WP_SCRIPT_TEXTDOMAIN_2);
+
+// Auto-tagging is only safe for single-domain projects. With two domains
+// configured we cannot infer which one an untagged call should get.
+$auto_tag = !$has_secondary;
+
+wp_script_run_make_pot(
+	WP_SCRIPT_TEXTDOMAIN,
+	$primary_dir,
+	$primary_exclude,
+	$primary_include,
+	$auto_tag
+);
+
+if ($has_secondary) {
+	$secondary_dir = defined('WP_SCRIPT_LANGUAGES_DIR_2') && WP_SCRIPT_LANGUAGES_DIR_2 ? WP_SCRIPT_LANGUAGES_DIR_2 : 'i18n';
+	$secondary_exclude = defined('WP_SCRIPT_EXCLUDE_2') ? WP_SCRIPT_EXCLUDE_2 : '';
+	$secondary_include = defined('WP_SCRIPT_INCLUDE_2') ? WP_SCRIPT_INCLUDE_2 : '';
+
+	wp_script_run_make_pot(
+		WP_SCRIPT_TEXTDOMAIN_2,
+		$secondary_dir,
+		$secondary_exclude,
+		$secondary_include,
+		false
+	);
+}
 
 echo "\n\n";
-

--- a/wp-script-config.sample.php
+++ b/wp-script-config.sample.php
@@ -15,7 +15,13 @@ define('WP_SCRIPT_TEXTDOMAIN','');
 // Comma-separated paths to exclude from the primary scan.
 // Mirrors `wp i18n make-pot --exclude=...`.
 // Default (when undefined): nothing extra is excluded.
-// define('WP_SCRIPT_EXCLUDE', 'pro,vendor,vendor-prefixed,node_modules,assets,tests,docs,bin');
+//
+// Do NOT exclude vendor-prefixed: Strauss-bundled in-house libraries
+// (ground-level-*, etc.) carry user-facing strings tagged with the plugin's
+// own textdomain, so excluding it silently drops them from the .pot. Prefer
+// excluding built JS output (assets/js/build) over all of assets/, or you'll
+// lose translatable JS strings (make-pot extracts JS too).
+// define('WP_SCRIPT_EXCLUDE', 'pro,vendor,node_modules,assets/js/build,tests,docs,bin');
 
 // Comma-separated paths to restrict the primary scan to.
 // Mirrors `wp i18n make-pot --include=...`. Usually unnecessary for a

--- a/wp-script-config.sample.php
+++ b/wp-script-config.sample.php
@@ -1,9 +1,44 @@
 <?php
 if(!defined('STDIN')) { die("You're unauthorized to view this page."); }
 
+// ===== Required =====
+// Primary textdomain — used by mki18n, deploy, etc.
 define('WP_SCRIPT_TEXTDOMAIN','');
+
+// ===== Optional: i18n customization =====
+// Directory where the .pot is written for the primary textdomain.
+// Defaults to 'i18n' (back-compat). Common modern choice: 'languages'.
+// If you pass a directory name as the first CLI arg to mki18n, that wins
+// over this constant.
+// define('WP_SCRIPT_LANGUAGES_DIR', 'languages');
+
+// Comma-separated paths to exclude from the primary scan.
+// Mirrors `wp i18n make-pot --exclude=...`.
+// Default (when undefined): nothing extra is excluded.
+// define('WP_SCRIPT_EXCLUDE', 'pro,vendor,vendor-prefixed,node_modules,assets,tests,docs,bin');
+
+// Comma-separated paths to restrict the primary scan to.
+// Mirrors `wp i18n make-pot --include=...`. Usually unnecessary for a
+// single-domain plugin; leave undefined to scan everything not excluded.
+// define('WP_SCRIPT_INCLUDE', '');
+
+// ===== Optional: secondary textdomain (e.g. Pro add-on bundled in same repo) =====
+// Define WP_SCRIPT_TEXTDOMAIN_2 to a non-empty string to make mki18n run a
+// second pass with this domain. Each `_2` constant mirrors its primary
+// counterpart. If WP_SCRIPT_TEXTDOMAIN_2 is undefined or empty, the second
+// pass is skipped — single-domain projects are unaffected.
+//
+// NOTE: when a secondary domain is configured, the auto-tag step
+// (add-textdomain.php) is skipped, since auto-tagging cannot tell which
+// domain an untagged string should belong to. Two-domain plugins must
+// tag every gettext call explicitly.
+// define('WP_SCRIPT_TEXTDOMAIN_2', '');
+// define('WP_SCRIPT_LANGUAGES_DIR_2', '');
+// define('WP_SCRIPT_EXCLUDE_2', '');
+// define('WP_SCRIPT_INCLUDE_2', '');
+
+// ===== Mothership / deploy =====
 define('MY_PLUGIN_MAIN_FILE', 'main.php');
 define('MOTHERSHIP_URL','');
 define('MOTHERSHIP_API_KEY','');
 define('MOTHERSHIP_PROJECT_ID','');
-


### PR DESCRIPTION
Plugins that bundle a Pro add-on (or any second textdomain) inside the same repo can now define optional WP_SCRIPT_TEXTDOMAIN_2 plus matching LANGUAGES_DIR_2 / EXCLUDE_2 / INCLUDE_2 constants. When set, mki18n runs a second `wp i18n make-pot` pass scoped to its own subtree and filtered to its own domain.

Single-domain projects are unaffected — every new constant is gated behind defined() and falls through to the original behavior.

Also exposes WP_SCRIPT_LANGUAGES_DIR / EXCLUDE / INCLUDE for the primary domain so callers can avoid the legacy `i18n/` default and pass scoping flags from config rather than CLI.

The auto-tag step (add-textdomain.php) is skipped when a secondary domain is configured: an untagged call cannot be unambiguously assigned to either domain, so two-domain plugins must tag every gettext call explicitly.