### PR TITLE
Support semver versions in deploy scripts; anchor validation

### DIFF
--- a/deploy
+++ b/deploy
@@ -9,16 +9,18 @@ if(!isset($argv[1])) { die("USAGE: ./script/deploy [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1). $m[1] only captures the legacy suffix word.
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 
 echo "!! Deploying version \"{$my_version}\"\n";
 //print_r($m);
 
-$my_branch = 'master'; 
-if(isset($m[2]) && !in_array($m[2], array('a','b','rc'))) {
-  $my_branch = $m[2]; 
+$my_branch = 'master';
+if(!empty($m[1]) && !in_array(strtolower($m[1]), array('a','b','rc'))) {
+  $my_branch = $m[1];
 }
 
 if(!defined('MY_PLUGIN_MAIN_FILE')) {

--- a/devdeploy
+++ b/devdeploy
@@ -9,7 +9,9 @@ if(!isset($argv[1])) { die("USAGE: ./script/deploy [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1).
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 

--- a/flow/deploy
+++ b/flow/deploy
@@ -9,16 +9,18 @@ if(!isset($argv[1])) { die("USAGE: ./script/flow/deploy [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1). $m[1] only captures the legacy suffix word.
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 
 echo "!! GIT Flow Deploying version \"{$my_version}\"\n";
 //print_r($m);
 
-$my_branch = 'develop'; 
-if(isset($m[2]) && !in_array($m[2], array('a','b','rc'))) {
-  $my_branch = $m[2]; 
+$my_branch = 'develop';
+if(!empty($m[1]) && !in_array(strtolower($m[1]), array('a','b','rc'))) {
+  $my_branch = $m[1];
 }
 
 if(!defined('MY_PLUGIN_MAIN_FILE')) {

--- a/flow/hotfix
+++ b/flow/hotfix
@@ -9,16 +9,18 @@ if(!isset($argv[1])) { die("USAGE: ./script/flow/hotfix [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1). $m[1] only captures the legacy suffix word.
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 
 echo "!! GIT Flow Deploying version \"{$my_version}\"\n";
 //print_r($m);
 
-$my_branch = 'master'; 
-if(isset($m[2]) && !in_array($m[2], array('a','b','rc'))) {
-  $my_branch = $m[2]; 
+$my_branch = 'master';
+if(!empty($m[1]) && !in_array(strtolower($m[1]), array('a','b','rc'))) {
+  $my_branch = $m[1];
 }
 
 if(!defined('MY_PLUGIN_MAIN_FILE')) {

--- a/flow/redeploy
+++ b/flow/redeploy
@@ -9,16 +9,18 @@ if(!isset($argv[1])) { die("USAGE: ./script/flow/redeploy [version-number]\n"); 
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1). $m[1] only captures the legacy suffix word.
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 
 echo "!! Re-Deploying version \"{$my_version}\"\n";
 //print_r($m);
 
-$my_branch = 'develop'; 
-if(isset($m[2]) && !in_array($m[2], array('a','b','rc'))) {
-  $my_branch = $m[2]; 
+$my_branch = 'develop';
+if(!empty($m[1]) && !in_array(strtolower($m[1]), array('a','b','rc'))) {
+  $my_branch = $m[1];
 }
 
 if(!defined('MY_PLUGIN_MAIN_FILE')) {

--- a/flow/undeploy
+++ b/flow/undeploy
@@ -9,7 +9,9 @@ if(!isset($argv[1])) { die("USAGE: ./script/flow/undeploy [version-number]\n"); 
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1).
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 

--- a/mcdeployall
+++ b/mcdeployall
@@ -13,7 +13,9 @@ if (!isset($argv[1])) {
 
 $version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $version)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1).
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $version)) {
     echo "Improper version format.\n";
     exit(1);
 }

--- a/mcdevdeploy
+++ b/mcdevdeploy
@@ -13,7 +13,9 @@ if (!isset($argv[1])) {
 
 $version = $argv[1];
 
-if (!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $version)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1).
+if (!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $version)) {
     echo "Improper version format.\n";
     exit(1);
 }

--- a/redeploy
+++ b/redeploy
@@ -9,16 +9,18 @@ if(!isset($argv[1])) { die("USAGE: ./script/deploy [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1). $m[1] only captures the legacy suffix word.
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 
 echo "!! Re-Deploying version \"{$my_version}\"\n";
 //print_r($m);
 
-$my_branch = 'master'; 
-if(isset($m[2]) && !in_array($m[2], array('a','b','rc'))) {
-  $my_branch = $m[2]; 
+$my_branch = 'master';
+if(!empty($m[1]) && !in_array(strtolower($m[1]), array('a','b','rc'))) {
+  $my_branch = $m[1];
 }
 
 if(!defined('MY_PLUGIN_MAIN_FILE')) {

--- a/undeploy
+++ b/undeploy
@@ -9,7 +9,9 @@ if(!isset($argv[1])) { die("USAGE: ./script/undeploy [version-number]\n"); }
 
 $my_version = $argv[1];
 
-if(!preg_match('/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i', $my_version, $m)) {
+// Accepts X.Y.Z, the legacy MemberPress prerelease convention (1.2.3rc1) and
+// semver prereleases (1.2.3-rc.1).
+if(!preg_match('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD', $my_version, $m)) {
   exit("Improper Version Format\n\n");
 }
 


### PR DESCRIPTION
Fixes #9

## Summary

Every deploy script validated the version argument with an unanchored regex `/\d+\.\d+\.\d+(([a-z_-]+)\d+)?/i` that:

1. modeled only the legacy MemberPress prerelease convention (`1.2.3rc1`), not semver prereleases (`1.2.3-rc.1`); and
2. being unanchored, matched anywhere in the string — so `1.2.3 ; rm -rf /` passed validation and was then interpolated into `system()` / `git tag` / `curl` command lines (command-injection vector).

## Change

Replaced it across all scripts with one anchored pattern:

```
/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+|([a-z_][a-z_-]*)\d+)?$/iD
```

- A **leading `-`** denotes a semver prerelease (`1.2.3-rc.1`, `1.2.3-alpha.1`, `1.2.3-beta`).
- A suffix starting with a letter/underscore is a **legacy** prerelease/branch; internal hyphens still allowed, so `1.2.3my-branch1` keeps deploying from branch `my-branch`.
- The `D` modifier rejects trailing-newline tricks.
- Branch detection updated for the new capture group (`$m[1]`, with `strtolower()`/`!empty()` guards).

Applied to: `deploy`, `devdeploy`, `redeploy`, `undeploy`, `mcdevdeploy`, `mcdeployall`, and `flow/{deploy,redeploy,hotfix,undeploy}` (10 scripts).

## Both conventions verified

| Input | Result |
|---|---|
| `1.2.3` | accept (release) |
| `1.2.3a1` / `1.2.3rc1` | accept (legacy prerelease) |
| `1.2.3feature1` | accept, branch `feature` |
| `1.2.3my-branch1` | accept, branch `my-branch` |
| `1.2.3-rc.1` / `1.2.3-alpha.1` / `1.2.3-beta` | accept (semver) |
| `garbage` / `1.2` / `v1.2.3` / `1.2.3 ; rm` / trailing `\n` | reject |

All 10 scripts pass `php -l`; the regex was tested by extracting it directly from the committed files.

> Intentional, narrow behavior change: a *leading-dash* legacy form like `1.2.3-foo1` is now read as a semver prerelease (deploy from the default branch) rather than a branch literally named `-foo`. Dash-led git branch names were always malformed, so only junk is affected; every well-formed legacy version behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)