### PR TITLE
rmtabs: opt-in per-project extension excludes (WP_SCRIPT_RMTABS_EXCLUDE_EXTS)

### DIFF
--- a/rmtabs
+++ b/rmtabs
@@ -1,6 +1,42 @@
 #!/bin/bash
+# Normalize indentation tabs -> 2 spaces in distributed source.
+#
+# By default this covers .php, .css, and .js (unchanged behavior). A project
+# can exclude one or more extensions by defining WP_SCRIPT_RMTABS_EXCLUDE_EXTS
+# (comma-separated) in script/wp-script-config.php, e.g.:
+#
+#   define('WP_SCRIPT_RMTABS_EXCLUDE_EXTS', 'js');
+#
+# Use this when a project's JS/CSS indentation is owned by Prettier/ESLint and
+# follows the WordPress tabs standard (e.g. Pretty Links) — tab stripping here
+# would fight the linter and break its CI gate. When the constant is
+# missing/empty (or the config file is absent), every extension is processed,
+# so existing projects are unaffected.
+
+exclude=""
+if [ -f ./script/wp-script-config.php ] && command -v php >/dev/null 2>&1; then
+  exclude=$(php -r "include './script/wp-script-config.php'; echo (defined('WP_SCRIPT_RMTABS_EXCLUDE_EXTS') ? WP_SCRIPT_RMTABS_EXCLUDE_EXTS : '');" 2>/dev/null)
+fi
+
+# Build the -name predicate from the default extension set minus any excluded.
+name_args=()
+for ext in php css js; do
+  skip=0
+  for x in $(echo "$exclude" | tr ',' ' '); do
+    x=$(echo "$x" | tr 'A-Z' 'a-z' | sed 's/^\.//')
+    [ "$x" = "$ext" ] && skip=1
+  done
+  if [ "$skip" -eq 0 ]; then
+    [ ${#name_args[@]} -gt 0 ] && name_args+=( -o )
+    name_args+=( -name "*.$ext" )
+  fi
+done
+
+# Every extension excluded -> nothing to do.
+[ ${#name_args[@]} -eq 0 ] && exit 0
+
 find . -regextype posix-extended \
   -iregex '\./(brand/add-ons|script|test|tmp).*|.*/(node_modules|vendor).*' -prune -o \
-  -type f \( -name '*.php' -o -name '*.css' -o -name '*.js' \) \
+  -type f \( "${name_args[@]}" \) \
   -print \
   -exec /usr/bin/perl -p -i -e 's/\t/  /g' {} +

--- a/wp-script-config.sample.php
+++ b/wp-script-config.sample.php
@@ -43,6 +43,15 @@ define('WP_SCRIPT_TEXTDOMAIN','');
 // define('WP_SCRIPT_EXCLUDE_2', '');
 // define('WP_SCRIPT_INCLUDE_2', '');
 
+// ===== Optional: whitespace normalization (rmtabs) =====
+// The deploy runs `rmtabs`, which converts indentation tabs -> 2 spaces in
+// distributed source (.php, .css, .js by default). If a project's JS (or CSS)
+// indentation is owned by Prettier/ESLint and follows the WordPress *tabs*
+// standard, list those extensions here so rmtabs leaves them alone — otherwise
+// it fights the linter and breaks the lint-js CI gate. Comma-separated, bare
+// extensions. Undefined/empty (the default) processes all extensions.
+// define('WP_SCRIPT_RMTABS_EXCLUDE_EXTS', 'js');
+
 // ===== Mothership / deploy =====
 define('MY_PLUGIN_MAIN_FILE', 'main.php');
 define('MOTHERSHIP_URL','');


### PR DESCRIPTION
Rebased clean onto master (supersedes #11, which diverged due to a stale local checkout).

## Problem

`rmtabs` (run by `deploy`/`devdeploy`) converts indentation tabs → 2 spaces across `.php`, `.css`, and `.js`. Projects whose JS indentation is owned by Prettier/ESLint on the WordPress **tabs** standard get their JS silently reformatted at deploy, breaking their `lint-js` CI gate. This bit Pretty Links 4.0.7 (27k `prettier/prettier` errors on `develop` after the release).

## Fix

Opt-in config constant `WP_SCRIPT_RMTABS_EXCLUDE_EXTS` (comma-separated extensions) that removes those extensions from the normalization pass:

```php
define('WP_SCRIPT_RMTABS_EXCLUDE_EXTS', 'js');
```

- **Backward compatible:** missing/empty constant, or no config file, processes all extensions as before — existing projects unaffected.
- Parsing tolerates spaces, leading dots, mixed case.
- `rmlb` / `cleartrailingwhitespace` untouched (CRLF + trailing-whitespace stripping is prettier-safe).

Documented in `wp-script-config.sample.php`. Verified across standalone, config-without-define, `exclude=js`, and `exclude='js, .CSS'`.